### PR TITLE
support of int and long types

### DIFF
--- a/LogAnalytics.Client/LogAnalytics.Client/LogAnalyticsClient.cs
+++ b/LogAnalytics.Client/LogAnalytics.Client/LogAnalyticsClient.cs
@@ -150,6 +150,8 @@ namespace LogAnalytics.Client
                 if (propertyInfo.PropertyType != typeof(string) &&
                     propertyInfo.PropertyType != typeof(bool) &&
                     propertyInfo.PropertyType != typeof(double) &&
+                    propertyInfo.PropertyType != typeof(int) &&
+                    propertyInfo.PropertyType != typeof(long) &&
                     propertyInfo.PropertyType != typeof(DateTime) &&
                     propertyInfo.PropertyType != typeof(Guid))
                 {


### PR DESCRIPTION
`int` and `long` are also correct types for the log entity.