### PR TITLE
Added support for integers, removed support for longs, updated end-to-end tests.

### DIFF
--- a/LogAnalytics.Client/LogAnalytics.Client.Tests/Tests/Client/End2EndTests.cs
+++ b/LogAnalytics.Client/LogAnalytics.Client.Tests/Tests/Client/End2EndTests.cs
@@ -46,7 +46,8 @@ namespace LogAnalytics.Client.Tests.Tests
                 {
                     Criticality = "e2ecriticality",
                     Message = testIdentifierEntries,
-                    SystemSource = "e2etest"
+                    SystemSource = "e2etest",
+                    Priority = int.MaxValue-1
                 });
             }
 
@@ -58,7 +59,8 @@ namespace LogAnalytics.Client.Tests.Tests
             {
                 Criticality = "e2ecriticalitysingleentry",
                 Message = testIdentifierEntry,
-                SystemSource = "e2etestsingleentry"
+                SystemSource = "e2etestsingleentry",
+                Priority = int.MinValue+1
             }, "endtoendlogs").Wait();
 
             // Since it takes a while before the logs are queryable, we'll sit tight and wait for a few minutes before we launch the retrieval-tests.
@@ -76,6 +78,7 @@ namespace LogAnalytics.Client.Tests.Tests
             Assert.AreEqual(testIdentifierEntries, entry["Message"]);
             Assert.AreEqual("e2etest", entry["SystemSource_s"]);
             Assert.AreEqual("e2ecriticality", entry["Criticality_s"]);
+            Assert.AreEqual($"{int.MaxValue-1}", entry["Priority_d"]);
         }
 
         [TestMethod]
@@ -88,6 +91,7 @@ namespace LogAnalytics.Client.Tests.Tests
             Assert.AreEqual(testIdentifierEntry, entry["Message"]);
             Assert.AreEqual("e2etestsingleentry", entry["SystemSource_s"]);
             Assert.AreEqual("e2ecriticalitysingleentry", entry["Criticality_s"]);
+            Assert.AreEqual($"{int.MinValue + 1}", entry["Priority_d"]);
         }
 
         // TODO: Enhance test coverage in the E2E tests

--- a/LogAnalytics.Client/LogAnalytics.Client.Tests/Tests/Client/LogAnalyticsClientTests.cs
+++ b/LogAnalytics.Client/LogAnalytics.Client.Tests/Tests/Client/LogAnalyticsClientTests.cs
@@ -43,7 +43,8 @@ namespace LogAnalytics.Client.Tests
                 TestBoolean = true,
                 TestDateTime = DateTime.UtcNow,
                 TestDouble = 2.1,
-                TestGuid = Guid.NewGuid()
+                TestGuid = Guid.NewGuid(),
+                TestInteger = 1234
             }, "demolog").Wait();
         }
 
@@ -61,7 +62,8 @@ namespace LogAnalytics.Client.Tests
                 {
                     Criticality = GetCriticality(),
                     Message = "lorem ipsum dolor sit amet",
-                    SystemSource = GetSystemSource()
+                    SystemSource = GetSystemSource(),
+                    Priority = 2
                 });
             }
 
@@ -86,8 +88,7 @@ namespace LogAnalytics.Client.Tests
                     MyCustomProperty = new MyCustomClass
                     {
                         MyString = "hello world",
-                    },
-                    TestInt = 123
+                    }
                 });
             }
 

--- a/LogAnalytics.Client/LogAnalytics.Client.Tests/Tests/Client/TestEntities/DemoEntity.cs
+++ b/LogAnalytics.Client/LogAnalytics.Client.Tests/Tests/Client/TestEntities/DemoEntity.cs
@@ -5,5 +5,6 @@
         public string Criticality { get; set; }
         public string SystemSource { get; set; }
         public string Message { get; set; }
+        public int Priority { get;set; }
     }
 }

--- a/LogAnalytics.Client/LogAnalytics.Client.Tests/Tests/Client/TestEntities/TestEntity.cs
+++ b/LogAnalytics.Client/LogAnalytics.Client.Tests/Tests/Client/TestEntities/TestEntity.cs
@@ -8,6 +8,7 @@ namespace LogAnalytics.Client.Tests.TestEntities
         public string TestString { get; set; }
         public bool TestBoolean { get; set; }
         public Double TestDouble { get; set; }
+        public int TestInteger { get;set;}
         public DateTime TestDateTime { get; set; }
         public Guid TestGuid { get; set; }
     }

--- a/LogAnalytics.Client/LogAnalytics.Client.Tests/Tests/Client/TestEntities/TestEntityBadProperties.cs
+++ b/LogAnalytics.Client/LogAnalytics.Client.Tests/Tests/Client/TestEntities/TestEntityBadProperties.cs
@@ -2,7 +2,7 @@
 {
     public class TestEntityBadProperties
     {
-        public int TestInt { get; set; }
+        public long LongIsNotWorking { get;set;}
         public MyCustomClass MyCustomProperty { get; set; }
     }
 

--- a/LogAnalytics.Client/LogAnalytics.Client/LogAnalyticsClient.cs
+++ b/LogAnalytics.Client/LogAnalytics.Client/LogAnalyticsClient.cs
@@ -147,15 +147,14 @@ namespace LogAnalytics.Client
             // anything else will be throwing an exception here.
             foreach (PropertyInfo propertyInfo in entity.GetType().GetProperties())
             {
-                if (propertyInfo.PropertyType != typeof(string) &&
-                    propertyInfo.PropertyType != typeof(bool) &&
-                    propertyInfo.PropertyType != typeof(double) &&
-                    propertyInfo.PropertyType != typeof(int) &&
-                    propertyInfo.PropertyType != typeof(long) &&
-                    propertyInfo.PropertyType != typeof(DateTime) &&
-                    propertyInfo.PropertyType != typeof(Guid))
+                if (propertyInfo.PropertyType != typeof(string) &&      // represented as columnName_s
+                    propertyInfo.PropertyType != typeof(bool) &&        // represented as columnName_b
+                    propertyInfo.PropertyType != typeof(double) &&      // represented as columnName_d
+                    propertyInfo.PropertyType != typeof(int) &&         // represented as columnName_d
+                    propertyInfo.PropertyType != typeof(DateTime) &&    // represented as columnName_t
+                    propertyInfo.PropertyType != typeof(Guid))          // represented as columnName_g
                 {
-                    throw new ArgumentOutOfRangeException($"Property '{propertyInfo.Name}' of entity with type '{entity.GetType()}' is not one of the valid properties. Valid properties are String, Boolean, Double, DateTime, Guid.");
+                    throw new ArgumentOutOfRangeException($"Property '{propertyInfo.Name}' of entity with type '{entity.GetType()}' is not one of the valid properties. Valid properties are String, Boolean, Double, Integer, DateTime, Guid.");
                 }
             }
         }


### PR DESCRIPTION
Reviewed and tested: 
- Integers work to send, and are stored as `yourColumn_d` (d for double, a supported type).
- Long is not supported. The long datatype is stored as `_d`, too, but is cut of because the values can be longer than allowed to store, resulting in flawed data being stored. Therefore we will not make use of the long datatype.
- End-to-end tests are green and work. 