### PR TITLE
Nuget bump to 1.1.0

### DIFF
--- a/LogAnalytics.Client/LogAnalytics.Client.Tests/LogAnalytics.Client.Tests.csproj
+++ b/LogAnalytics.Client/LogAnalytics.Client.Tests/LogAnalytics.Client.Tests.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" Version="2.4.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />

--- a/LogAnalytics.Client/LogAnalytics.Client.Tests/LogAnalytics.Client.Tests.csproj
+++ b/LogAnalytics.Client/LogAnalytics.Client.Tests/LogAnalytics.Client.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" Version="2.4.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />

--- a/LogAnalytics.Client/LogAnalytics.Client/LogAnalytics.Client.csproj
+++ b/LogAnalytics.Client/LogAnalytics.Client/LogAnalytics.Client.csproj
@@ -9,7 +9,7 @@
 Easily send C# entities as log entries to the Log Analytics Workspace.</Description>
     <PackageProjectUrl>https://github.com/Zimmergren/LogAnalytics.Client</PackageProjectUrl>
     <PackageId>LogAnalytics.Client</PackageId>
-    <Version>1.0.7</Version>    
+    <Version>1.1.0</Version>    
     <PackageDescription>A .NET Core client for Azure Log Analytics</PackageDescription>
     <RepositoryUrl>https://github.com/Zimmergren/LogAnalytics.Client</RepositoryUrl>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>

--- a/LogAnalytics.Client/LogAnalytics.Client/LogAnalytics.Client.csproj
+++ b/LogAnalytics.Client/LogAnalytics.Client/LogAnalytics.Client.csproj
@@ -20,7 +20,7 @@ Easily send C# entities as log entries to the Log Analytics Workspace.</Descript
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Azure.OperationalInsights" Version="0.10.0-preview" />
+    <PackageReference Include="Microsoft.Azure.OperationalInsights" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Install-Package LogAnalytics.Client
 
 #### Install by adding a PackageReference to csproj
 ```xml
-<PackageReference Include="LogAnalytics.Client" Version="1.0.7" />
+<PackageReference Include="LogAnalytics.Client" Version="1.1.0" />
 ```
 
 #### Install using Paket CLI

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,7 @@ We apply security updates as applicable to the latest version of the LogAnalytic
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 1.1.0   | :white_check_mark: |
 | 1.0.7   | :white_check_mark: |
 | 1.0.6   | :white_check_mark: |
 | 1.0.5   | :white_check_mark: |


### PR DESCRIPTION
Upgraded the LogAnalytics.Client NuGet to v1.1.0. 
- Upgraded dependency Microsoft.Azure.OperationalInsights to v1.0.0. Previously 0.10.0-preview.
- Upgraded test dependencies to their latest released versions.
- Bumped version to v1.1.0.