### PR TITLE
Di friendly

### DIFF
--- a/LogAnalytics.Client/LogAnalytics.Client.IntegrationTests/Helpers/LawDataClientHelper.cs
+++ b/LogAnalytics.Client/LogAnalytics.Client.IntegrationTests/Helpers/LawDataClientHelper.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Azure.OperationalInsights;
+using Microsoft.Rest.Azure.Authentication;
+using System;
+using System.Threading.Tasks;
+
+namespace LogAnalytics.Client.IntegrationTests.Helpers
+{
+    public static class LawDataClientHelper
+    {
+        public static async Task<OperationalInsightsDataClient> GetLawDataClient(string workspaceId, string lawPrincipalClientId, string lawPrincipalClientSecret, string domain)
+        {
+            // Note 2020-07-26. This is from the Microsoft.Azure.OperationalInsights nuget, which haven't been updated since 2018. 
+            // Possibly we'll look for a REST-approach instead, and create the proper client here.
+
+            var authEndpoint = "https://login.microsoftonline.com";
+            var tokenAudience = "https://api.loganalytics.io/";
+
+            var adSettings = new ActiveDirectoryServiceSettings
+            {
+                AuthenticationEndpoint = new Uri(authEndpoint),
+                TokenAudience = new Uri(tokenAudience),
+                ValidateAuthority = true
+            };
+
+            var credentials = await ApplicationTokenProvider.LoginSilentAsync(domain, lawPrincipalClientId, lawPrincipalClientSecret, adSettings);
+
+            var client = new OperationalInsightsDataClient(credentials)
+            {
+                WorkspaceId = workspaceId
+            };
+
+            return client;
+        }
+    }
+}

--- a/LogAnalytics.Client/LogAnalytics.Client.IntegrationTests/LogAnalytics.Client.IntegrationTests.csproj
+++ b/LogAnalytics.Client/LogAnalytics.Client.IntegrationTests/LogAnalytics.Client.IntegrationTests.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.11" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" Version="2.4.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />

--- a/LogAnalytics.Client/LogAnalytics.Client.UnitTests/DependencyInjectionExtensionsTests.cs
+++ b/LogAnalytics.Client/LogAnalytics.Client.UnitTests/DependencyInjectionExtensionsTests.cs
@@ -1,0 +1,55 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using Xunit;
+
+namespace LogAnalytics.Client.UnitTests
+{
+    public class DependencyInjectionExtensionsTests
+    {
+        [Fact]
+        public void LogAnalyticsClient_ShouldCreateInstanceWithConfigurationAction()
+        {
+            // Arrange
+            var provider = new ServiceCollection()
+                .AddLogAnalyticsClient(c =>
+            {
+                c.WorkspaceId = "workspaceId";
+                c.SharedKey = Convert.ToBase64String(Encoding.UTF8.GetBytes("sharredKey"));
+            }).BuildServiceProvider();
+
+            // Act
+            var instance = provider.GetRequiredService<LogAnalyticsClient>();
+
+            // Assert
+            Assert.NotNull(instance);
+        }
+
+        [Fact]
+        public void LogAnalyticsClient_ShouldCreateInstanceWithConfiguratinInstance()
+        {
+            // Arrange
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "LogAnalytics:WorkspaceId", "workspaceId" },
+                    { "LogAnalytics:SharedKey", Convert.ToBase64String(Encoding.UTF8.GetBytes("sharredKey")) }
+                })
+                .Build();
+
+            var provider = new ServiceCollection()
+                .AddLogAnalyticsClient(configuration.GetSection("LogAnalytics"))
+                .BuildServiceProvider();
+            // Act
+            var instance = provider.GetRequiredService<LogAnalyticsClient>();
+
+            // Assert
+            Assert.NotNull(instance);
+        }
+    }
+}

--- a/LogAnalytics.Client/LogAnalytics.Client.UnitTests/DependencyInjectionExtensionsTests.cs
+++ b/LogAnalytics.Client/LogAnalytics.Client.UnitTests/DependencyInjectionExtensionsTests.cs
@@ -20,7 +20,7 @@ namespace LogAnalytics.Client.UnitTests
                 .AddLogAnalyticsClient(c =>
             {
                 c.WorkspaceId = "workspaceId";
-                c.SharedKey = Convert.ToBase64String(Encoding.UTF8.GetBytes("sharredKey"));
+                c.SharedKey = Convert.ToBase64String(Encoding.UTF8.GetBytes("sharedKey"));
             }).BuildServiceProvider();
 
             // Act
@@ -38,7 +38,7 @@ namespace LogAnalytics.Client.UnitTests
                 .AddInMemoryCollection(new Dictionary<string, string>
                 {
                     { "LogAnalytics:WorkspaceId", "workspaceId" },
-                    { "LogAnalytics:SharedKey", Convert.ToBase64String(Encoding.UTF8.GetBytes("sharredKey")) }
+                    { "LogAnalytics:SharedKey", Convert.ToBase64String(Encoding.UTF8.GetBytes("sharedKey")) }
                 })
                 .Build();
 

--- a/LogAnalytics.Client/LogAnalytics.Client.UnitTests/LogAnalytics.Client.UnitTests.csproj
+++ b/LogAnalytics.Client/LogAnalytics.Client.UnitTests/LogAnalytics.Client.UnitTests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac.Extras.Moq" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/LogAnalytics.Client/LogAnalytics.Client.UnitTests/LogAnalytics.Client.UnitTests.csproj
+++ b/LogAnalytics.Client/LogAnalytics.Client.UnitTests/LogAnalytics.Client.UnitTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac.Extras.Moq" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/LogAnalytics.Client/LogAnalytics.Client.UnitTests/LogAnalyticsClientTests.cs
+++ b/LogAnalytics.Client/LogAnalytics.Client.UnitTests/LogAnalyticsClientTests.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using Xunit;
 
-namespace LogAnalytics.Client.IntegrationTests.UnitTests
+namespace LogAnalytics.Client.UnitTests
 {
     public class LogAnalyticsClientTests
     {

--- a/LogAnalytics.Client/LogAnalytics.Client/DependencyInjectionExtensions.cs
+++ b/LogAnalytics.Client/LogAnalytics.Client/DependencyInjectionExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LogAnalytics.Client
+{
+    public static class DependencyInjectionExtensions
+    {
+        private static IServiceCollection AddLogAnalyticsClient(this IServiceCollection services)
+        {
+            services.AddHttpClient<LogAnalyticsClient>();
+            return services;
+        }
+
+        /// <summary>
+        /// Add Log Analytics Client to the service container using HTTP Client Factory.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
+        /// <param name="configureAction">The action used to configure the options.</param>
+        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+        public static IServiceCollection AddLogAnalyticsClient(this IServiceCollection services, Action<LogAnalyticsClientOptions> configureAction)
+        {
+            services.Configure(configureAction);
+            return services.AddLogAnalyticsClient();
+        }
+
+        /// <summary>
+        /// Add Log Analytics Client to the service container using HTTP Client Factory.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
+        /// <param name="configuration">Configuration or configuration section.</param>
+        /// <returns></returns>
+        public static IServiceCollection AddLogAnalyticsClient(this IServiceCollection services, IConfiguration configuration)
+        {
+            services.AddOptions<LogAnalyticsClientOptions>().Bind(configuration);
+            return services.AddLogAnalyticsClient();
+        }
+    }
+}

--- a/LogAnalytics.Client/LogAnalytics.Client/LogAnalytics.Client.csproj
+++ b/LogAnalytics.Client/LogAnalytics.Client/LogAnalytics.Client.csproj
@@ -21,10 +21,10 @@ The easiest way to send logs to Azure Log Analytics from your .NET Core applicat
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.OperationalInsights" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.11" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.11" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.11" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.11" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/LogAnalytics.Client/LogAnalytics.Client/LogAnalytics.Client.csproj
+++ b/LogAnalytics.Client/LogAnalytics.Client/LogAnalytics.Client.csproj
@@ -21,6 +21,10 @@ The easiest way to send logs to Azure Log Analytics from your .NET Core applicat
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.OperationalInsights" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/LogAnalytics.Client/LogAnalytics.Client/LogAnalyticsClientOptions.cs
+++ b/LogAnalytics.Client/LogAnalytics.Client/LogAnalyticsClientOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace LogAnalytics.Client
+{
+    public class LogAnalyticsClientOptions
+    {
+        public string WorkspaceId { get; set; }
+        public string SharedKey { get; set; }
+    }
+}


### PR DESCRIPTION
Solves: #28 

Now it is easy to register LogAnalyticsClient into DI container.

```cs
// Typical ASP .NET Core use case
IConfiguration Configuration; // ...
services.AddLogAnalyticsClient(Configuration.GetSection("LogAnalytics"));

// manual configuration
services.AddLogAnalyticsClient(c =>
            {
                c.WorkspaceId = "workspaceId";
                c.SharedKey = Convert.ToBase64String(Encoding.UTF8.GetBytes("sharredKey"));
            });
```

now the HttpClient and HttpMessageHandler will be managed by the factory.
https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests