### PR TITLE
Upgraded the project to .NET 6

### DIFF
--- a/LogAnalytics.Client/LogAnalytics.Client.IntegrationTests/LogAnalytics.Client.IntegrationTests.csproj
+++ b/LogAnalytics.Client/LogAnalytics.Client.IntegrationTests/LogAnalytics.Client.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" Version="2.4.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />

--- a/LogAnalytics.Client/LogAnalytics.Client.UnitTests/LogAnalytics.Client.UnitTests.csproj
+++ b/LogAnalytics.Client/LogAnalytics.Client.UnitTests/LogAnalytics.Client.UnitTests.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/LogAnalytics.Client/LogAnalytics.Client/LogAnalytics.Client.csproj
+++ b/LogAnalytics.Client/LogAnalytics.Client/LogAnalytics.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Authors>Zimmergren</Authors>
     <Company>Zimmergren</Company>
     <Product>LogAnalytics.Client</Product>
@@ -9,8 +9,8 @@
 The easiest way to send logs to Azure Log Analytics from your .NET Core applications.</Description>
     <PackageProjectUrl>https://github.com/Zimmergren/LogAnalytics.Client</PackageProjectUrl>
     <PackageId>LogAnalytics.Client</PackageId>
-    <Version>5.2.1</Version>    
-    <PackageDescription>A .NET Core client for Azure Log Analytics</PackageDescription>
+    <Version>6.0.0</Version>    
+    <PackageDescription>A .NET client for Azure Log Analytics. Compatible with .NET Core, .NET 5 and .NET 6</PackageDescription>
     <RepositoryUrl>https://github.com/Zimmergren/LogAnalytics.Client</RepositoryUrl>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
   </PropertyGroup>
@@ -33,10 +33,10 @@ The easiest way to send logs to Azure Log Analytics from your .NET Core applicat
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.OperationalInsights" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.333">
       <PrivateAssets>all</PrivateAssets>

--- a/README.md
+++ b/README.md
@@ -9,8 +9,16 @@ Construct a custom object and send it to Log Analytics. It will be represented a
 ## NuGet
 The [LogAnalytics.Client](https://www.nuget.org/packages/loganalytics.client) is available on NuGet.
 
-## Support for .NET 5
-The LogAnalytics.Client project has been upgraded to .NET 5, and bumped the major version to 5.x. 
+## Support for .NET 6
+The LogAnalytics.Client project has been upgraded to .NET 6, and bumped the major version to 6.x. 
+
+LogAnalytics.Client currently support the below versions of .NET.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| .NET 6.x   | :white_check_mark: |
+| .NET 5.x   | :white_check_mark: |
+| .NET Core 3.x | :white_check_mark: |
 
 ## How to use the LogAnalytics Client
 
@@ -28,7 +36,7 @@ Install-Package LogAnalytics.Client
 
 #### Install by adding a PackageReference to csproj
 ```xml
-<PackageReference Include="LogAnalytics.Client" Version="5.2.1" />
+<PackageReference Include="LogAnalytics.Client" Version="6.0.0" />
 ```
 
 #### Install using Paket CLI

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,20 +1,17 @@
 # Security Policy
 With modern technology and capabilities come modern threats. 
-We apply regular- and security updates as applicable to LogAnalytics.Client.
+We apply regular- and security-updates as applicable to the latest version of LogAnalytics.Client.
 
 ## Currently Supported Versions
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 6.0.0   | :white_check_mark: |
 | 5.2.1   | :white_check_mark: |
 | 5.2.0   | :white_check_mark: |
 | 5.1.0   | :white_check_mark: |
 | 5.0.0   | :white_check_mark: |
 | 1.3.2   | :white_check_mark: |
-| 1.3.1   | :white_check_mark: |
-| 1.3.0   | :white_check_mark: |
-| 1.3.0   | :white_check_mark: |
-| 1.2.0   | :white_check_mark: |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
The LogAnalytics.Client project has been upgraded to support .NET 6, which recently shipped as RTM with LTS.